### PR TITLE
Fix a bug inside the zoom function related to the sufficient decrease condition

### DIFF
--- a/Line Search Algorithms.ipynb
+++ b/Line Search Algorithms.ipynb
@@ -471,7 +471,7 @@
     "        fj = func(x + alpha_j*pk, linesearch=True, symb='bo')\n",
     "\n",
     "        # Check if the sufficient decrease condition is violated\n",
-    "        if fj > fk + c1*alpha_j or fj >= f_low:\n",
+    "        if fj > fk + c1*alpha_j*proj_gk or fj >= f_low:\n",
     "            if verbose:\n",
     "                print('Zoom: Sufficient decrease conditions violated')\n",
     "            alpha_high = alpha_j\n",


### PR DESCRIPTION
There is a typo inside the *zoom()* function related to the check of the **sufficient decrease condition**. It is now fixed.